### PR TITLE
fix: re-process all when force_refresh is supplied

### DIFF
--- a/1password.py
+++ b/1password.py
@@ -101,7 +101,7 @@ def pre_get_credentials(config: dict, arguments: argparse.Namespace, profiles: d
             valid_cache_session = cache_session and cache_lib.valid_cache_session(cache_session)
 
             mfa_serial = profile_lib.get_mfa_serial(profiles, first_profile_name)
-            if mfa_serial and not valid_cache_session and not arguments.mfa_token:
+            if mfa_serial and (not valid_cache_session or arguments.force_refresh) and not arguments.mfa_token:
                 item = find_item(config, mfa_serial)
                 if item:
                     arguments.mfa_token = get_otp(item)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='awsume-1password-plugin',
-    version='1.2.0',
+    version='1.2.1',
     description='Automates awsume MFA entry via 1Password CLI.',
     entry_points={
         'awsume': [


### PR DESCRIPTION
When I ran awsume with the `-r` or `--refresh` flags, the plugin would not intercept the request, so I had to manually enter MFA.