### PR TITLE
fix: avoid plugin flow if target_profile_doesn't exists

### DIFF
--- a/1password.py
+++ b/1password.py
@@ -91,6 +91,9 @@ def handle_crash():
 def pre_get_credentials(config: dict, arguments: argparse.Namespace, profiles: dict):
     try:
         target_profile_name = profile_lib.get_profile_name(config, profiles, arguments.target_profile_name)
+        if not profiles.get(target_profile_name):
+            logger.debug('No profile %s found, skip plugin flow' % target_profile_name)
+            return None
         if target_profile_name != None:
             role_chain = profile_lib.get_role_chain(config, arguments, profiles, target_profile_name)
             first_profile_name = role_chain[0]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='awsume-1password-plugin',
-    version='1.2.0',
+    version='1.2.2',
     description='Automates awsume MFA entry via 1Password CLI.',
     entry_points={
         'awsume': [


### PR DESCRIPTION
This case is yet managed by AWSUME main process, so I think that the plugin error could be skipped.