### PR TITLE
fix ValueError: unsupported format character ',' (0x2c) at index 27

### DIFF
--- a/1password.py
+++ b/1password.py
@@ -107,7 +107,7 @@ def pre_get_credentials(config: dict, arguments: argparse.Namespace, profiles: d
             source_access_key_id = source_credentials.get('AccessKeyId')
             if source_access_key_id == None:
                 logger.debug(
-                    'No access key for profile %, skip plugin flow'
+                    'No access key for profile %s, skip plugin flow'
                     % target_profile_name
                 )
                 return None


### PR DESCRIPTION
In context of AWS Identity Center based profiles I observed an error out of a typo in the error handling, which this is the fix for.
```
Traceback (most recent call last):
  File "/Users/username/.local/pipx/venvs/awsume/lib/python3.12/site-packages/1password.py", line 110, in pre_get_credentials
    'No access key for profile %, skip plugin flow'
ValueError: unsupported format character ',' (0x2c) at index 27

```